### PR TITLE
Fixes issue #2. Added provides() method to Service Provider...

### DIFF
--- a/src/SoundcloudProvider.php
+++ b/src/SoundcloudProvider.php
@@ -30,4 +30,14 @@ class SoundcloudProvider extends ServiceProvider
             return new SoundcloudFacade($client, $secret, $callback);
         });
     }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return ['Soundcloud'];
+    }
 }


### PR DESCRIPTION
This is required by Laravel 5 for deferred service providers.

This solved issue #2.  According to Laravel 5 documentation (http://laravel.com/docs/master/providers), Deferred service providers need a provides() method that returns the name of the binding.

```
To defer the loading of a provider, set the defer property to true and define a provides method. The provides method returns the service container bindings that the provider registers:
```
